### PR TITLE
Add JWT and role-based guards to test controllers

### DIFF
--- a/src/database-test/database-test.controller.ts
+++ b/src/database-test/database-test.controller.ts
@@ -12,12 +12,18 @@ import {
 import { DatabaseTestService } from './database-test.service';
 import { CreateDatabaseTestDto } from './dto/create-database-test.dto';
 import { UpdateDatabaseTestDto } from './dto/update-database-test.dto';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { ThrottlerGuard } from '@nestjs/throttler';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '../user/role.enum';
 
 @ApiTags('Database Test')
+@ApiBearerAuth()
 @Controller('database-test')
-@UseGuards(ThrottlerGuard)
+@UseGuards(JwtAuthGuard, RolesGuard, ThrottlerGuard)
+@Roles(Role.DEVELOPER)
 export class DatabaseTestController {
     constructor(private readonly databaseTestService: DatabaseTestService) {}
 

--- a/src/email-notification-test/email-notification-test.controller.ts
+++ b/src/email-notification-test/email-notification-test.controller.ts
@@ -1,10 +1,17 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Post, Body, UseGuards } from '@nestjs/common';
 import { EmailNotificationTestService } from './email-notification-test.service';
 import { SendEmailDto } from './dto/send-email.dto';
-import { ApiTags, ApiOperation, ApiBody } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiBody, ApiBearerAuth } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '../user/role.enum';
 
 @ApiTags('Email Notification Test')
+@ApiBearerAuth()
 @Controller('email-notification-test')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.DEVELOPER)
 export class EmailNotificationTestController {
     constructor(
         private readonly emailNotificationTestService: EmailNotificationTestService,


### PR DESCRIPTION
Secured the DatabaseTestController and EmailNotificationTestController by adding JwtAuthGuard, RolesGuard, and restricting access to users with the DEVELOPER role. Also added ApiBearerAuth for Swagger documentation.